### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,20 @@ Custom Switch
 
 A custom Switch created with UIViews and UIButtons in Swift.
 
-##Example
+## Example
  
 ![alt tag](http://i.imgur.com/JkMJJ6L.gif)
 
-##Requirements
+## Requirements
 * iOS 7.0+
 
-##Installation
+## Installation
 * The Switch is subclassed so it can be easily used throughout your app
 * Just copy the CustomSwitch.swift file and add it to your project
 * There is also an example of how to create a color gradient procedurally in Swift
 
-##License 
+## License 
 MIT License
 
-##Author
+## Author
 Chad Timmerman - http://twitter.com/chadtimmerman


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
